### PR TITLE
Merge @deprecation comment changes into master

### DIFF
--- a/common/config/azure-pipelines/jobs/version-bump.yaml
+++ b/common/config/azure-pipelines/jobs/version-bump.yaml
@@ -155,7 +155,19 @@ jobs:
       - bash: |
           git config --local user.email imodeljs-admin@users.noreply.github.com
           git config --local user.name imodeljs-admin
+<<<<<<< HEAD
         displayName: Setup Git
+=======
+          echo "Checking if env variables were set:"
+          echo "token is ${GH_TOKEN:0:18}"
+          echo "other test var is $(TESTVAR)"
+          echo "other test var with different syntax is ${TESTVAR}"
+          echo "test var but slice ${TESTVAR:0:5}"
+        displayName: Setup Git
+        env:
+          GH_TOKEN: $(GH_TOKEN)
+          TESTVAR: $(TESTVAR)
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
       - bash: |
           git fetch --all
@@ -230,16 +242,37 @@ jobs:
                 # Commit and push all changes
                 git add .
                 git commit -m "Add deprecation comment changes with all merge conflicts"
+<<<<<<< HEAD
                 git push https://$(MYGITHUBTOKEN)@github.com/augustasgri/itwinjs-core-fork $conflictBranchName
                 echo "Now manually fix conflicts on branch '$conflictBranchName' and merge changes into master"
 
                 # Create a PR with new conflict branch
                 gh pr create --title "Merge @deprecation comment changes into master" --body "This PR contains all changes after running lint-deprecation ESLint rule and merging with master. Manual intervention required: solve conflicts in this branch and merge PR into master. This happened because @deprecation comments in master and in release branch could not be merged automatically." --draft
+=======
+                git push --set-upstream https://$(MYGITHUBTOKEN)@github.com/augustasgri/itwinjs-core-fork $conflictBranchName
+                echo "Now manually fix conflicts on branch '$conflictBranchName' and merge changes into master"
+
+                echo "checking remote"
+                git remote -v
+
+                echo "checking remote branches"
+                git branch -a | grep cherry-pick
+
+                git fetch
+
+                # Create a PR with new conflict branch
+                gh pr create --title "Merge @deprecation comment changes into master" --body "This PR contains all changes after running lint-deprecation ESLint rule and merging with master. Manual intervention required: solve conflicts in this branch and merge PR into master. This happened because @deprecation comments in master and in release branch could not be merged automatically." --draft --head $conflictBranchName
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
               fi
             displayName: Perform cherry-pick operation for deprecation changes
             name: cherryPickMaster
             continueOnError: true
             condition: eq(variables['changesDetected'], 'true')
+<<<<<<< HEAD
+=======
+            env:
+              GH_TOKEN: $(GH_TOKEN)
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
           - bash: git checkout $(deprecationCommit.hash)
             displayName: Checkout back to branch that ran the pipeline

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -2,7 +2,11 @@
   {
     "policyName": "prerelease-monorepo-lockStep",
     "definitionName": "lockStepVersion",
+<<<<<<< HEAD
     "version": "5.1.0-dev.36",
+=======
+    "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
     "nextBump": "prerelease"
   }
 ]

--- a/core/backend/CHANGELOG.json
+++ b/core/backend/CHANGELOG.json
@@ -2,6 +2,87 @@
   "name": "@itwin/core-backend",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/core-backend_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/core-backend_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/core-backend_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/core-backend_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/core-backend_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {
+        "none": [
+          {
+            "comment": "Add Symbols to prevent duplicate instances of package"
+          },
+          {
+            "comment": "Fix applychangeset issue"
+          },
+          {
+            "comment": "Mark iModel edit API as @preview"
+          },
+          {
+            "comment": "Fix regression when using performCheckpoint()"
+          },
+          {
+            "comment": "Add SheetViewDefinition.create, CreateSheetViewDefinitionArgs"
+          },
+          {
+            "comment": "optionally return world CRS from getAvailableCoordinateReferenceSystems"
+          },
+          {
+            "comment": "Refactoring the TextAnnotationGeometry and adding support for frames"
+          },
+          {
+            "comment": "Improve change unifer to handle very large changeset"
+          },
+          {
+            "comment": "Clear iModelDb Caches on abandonChanges"
+          },
+          {
+            "comment": "Thining iModelPlatform API"
+          },
+          {
+            "comment": "Updates iModelDb Error Handling"
+          },
+          {
+            "comment": "Reduce Model and Element Cache Size"
+          },
+          {
+            "comment": "Fix TextStyle.widthFactor multiplying by height instead of width during text layout."
+          },
+          {
+            "comment": "Snapshot/StandaloneDb.createBlank - set ecefLocation and geographicCoordinateSystem if provided"
+          },
+          {
+            "comment": "Add Beta downloadChangeset and downloadChangesets to BriefcaseManager."
+          }
+        ]
+      }
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/core-backend_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/core/backend/CHANGELOG.md
+++ b/core/backend/CHANGELOG.md
@@ -1,6 +1,51 @@
 # Change Log - @itwin/core-backend
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+### Updates
+
+- Add Symbols to prevent duplicate instances of package
+- Fix applychangeset issue
+- Mark iModel edit API as @preview
+- Fix regression when using performCheckpoint()
+- Add SheetViewDefinition.create, CreateSheetViewDefinitionArgs
+- optionally return world CRS from getAvailableCoordinateReferenceSystems
+- Refactoring the TextAnnotationGeometry and adding support for frames
+- Improve change unifer to handle very large changeset
+- Clear iModelDb Caches on abandonChanges
+- Thining iModelPlatform API
+- Updates iModelDb Error Handling
+- Reduce Model and Element Cache Size
+- Fix TextStyle.widthFactor multiplying by height instead of width during text layout.
+- Snapshot/StandaloneDb.createBlank - set ecefLocation and geographicCoordinateSystem if provided
+- Add Beta downloadChangeset and downloadChangesets to BriefcaseManager.
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/core/backend/package.json
+++ b/core/backend/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/core-backend",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "iTwin.js backend components",
   "main": "lib/cjs/core-backend.js",
   "module": "lib/esm/core-backend.js",
@@ -125,4 +129,8 @@
   "nyc": {
     "extends": "./node_modules/@itwin/build-tools/.nycrc"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/core/bentley/CHANGELOG.json
+++ b/core/bentley/CHANGELOG.json
@@ -2,6 +2,45 @@
   "name": "@itwin/core-bentley",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/core-bentley_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/core-bentley_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/core-bentley_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/core-bentley_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/core-bentley_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {
+        "none": [
+          {
+            "comment": "Add compareArrays for ordered comparison of arrays."
+          }
+        ]
+      }
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/core-bentley_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/core/bentley/CHANGELOG.md
+++ b/core/bentley/CHANGELOG.md
@@ -1,6 +1,37 @@
 # Change Log - @itwin/core-bentley
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+### Updates
+
+- Add compareArrays for ordered comparison of arrays.
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/core/bentley/package.json
+++ b/core/bentley/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/core-bentley",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "Bentley JavaScript core components",
   "main": "lib/cjs/core-bentley.js",
   "module": "lib/esm/core-bentley.js",
@@ -48,4 +52,8 @@
   "nyc": {
     "extends": "./node_modules/@itwin/build-tools/.nycrc"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/core/common/CHANGELOG.json
+++ b/core/common/CHANGELOG.json
@@ -2,6 +2,51 @@
   "name": "@itwin/core-common",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/core-common_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/core-common_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/core-common_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/core-common_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/core-common_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {
+        "none": [
+          {
+            "comment": "Mark iModel edit API as @preview"
+          },
+          {
+            "comment": "Refactoring the TextAnnotationGeometry and adding support for frames"
+          },
+          {
+            "comment": "Thinning iModelPlatform API"
+          }
+        ]
+      }
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/core-common_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/core/common/CHANGELOG.md
+++ b/core/common/CHANGELOG.md
@@ -1,6 +1,39 @@
 # Change Log - @itwin/core-common
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+### Updates
+
+- Mark iModel edit API as @preview
+- Refactoring the TextAnnotationGeometry and adding support for frames
+- Thinning iModelPlatform API
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/core/common/package.json
+++ b/core/common/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/core-common",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "iTwin.js components common to frontend and backend",
   "main": "lib/cjs/core-common.js",
   "module": "lib/esm/core-common.js",
@@ -64,4 +68,8 @@
     "extends": "./node_modules/@itwin/build-tools/.nycrc",
     "all": true
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/core/ecschema-editing/CHANGELOG.json
+++ b/core/ecschema-editing/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/ecschema-editing",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/ecschema-editing_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/ecschema-editing_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/ecschema-editing_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/ecschema-editing_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/ecschema-editing_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/ecschema-editing_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/core/ecschema-editing/CHANGELOG.md
+++ b/core/ecschema-editing/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Change Log - @itwin/ecschema-editing
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+_Version update only_
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/core/ecschema-editing/package.json
+++ b/core/ecschema-editing/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/ecschema-editing",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "ECSchema editing and validation API",
   "license": "MIT",
   "main": "lib/cjs/ecschema-editing.js",
@@ -71,4 +75,8 @@
   "nyc": {
     "extends": "./node_modules/@itwin/build-tools/.nycrc"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/core/ecschema-locaters/CHANGELOG.json
+++ b/core/ecschema-locaters/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/ecschema-locaters",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/ecschema-locaters_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/ecschema-locaters_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/ecschema-locaters_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/ecschema-locaters_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/ecschema-locaters_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/ecschema-locaters_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/core/ecschema-locaters/CHANGELOG.md
+++ b/core/ecschema-locaters/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Change Log - @itwin/ecschema-locaters
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+_Version update only_
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/core/ecschema-locaters/package.json
+++ b/core/ecschema-locaters/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/ecschema-locaters",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "EC Schema file locaters",
   "license": "MIT",
   "main": "lib/cjs/ecschema-locaters.js",
@@ -84,4 +88,8 @@
     "extends": "./node_modules/@itwin/build-tools/.nycrc",
     "sourceMap": false
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/core/ecschema-metadata/CHANGELOG.json
+++ b/core/ecschema-metadata/CHANGELOG.json
@@ -2,6 +2,51 @@
   "name": "@itwin/ecschema-metadata",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/ecschema-metadata_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/ecschema-metadata_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/ecschema-metadata_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/ecschema-metadata_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/ecschema-metadata_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {
+        "none": [
+          {
+            "comment": "Both buildPropertyCache and buildPropertyCacheSync, take no parameters and build the cache in house and return the cache map. Additionally, mergeProperties is now removed."
+          },
+          {
+            "comment": "Handle SI and METRIC unit systems as one unit system in SchemaFormatsProvider"
+          },
+          {
+            "comment": "Gracefully handle errors, including rpc, when retrieving schema items in `SchemaFormatsProvider`"
+          }
+        ]
+      }
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/ecschema-metadata_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/core/ecschema-metadata/CHANGELOG.md
+++ b/core/ecschema-metadata/CHANGELOG.md
@@ -1,6 +1,39 @@
 # Change Log - @itwin/ecschema-metadata
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+### Updates
+
+- Both buildPropertyCache and buildPropertyCacheSync, take no parameters and build the cache in house and return the cache map. Additionally, mergeProperties is now removed.
+- Handle SI and METRIC unit systems as one unit system in SchemaFormatsProvider
+- Gracefully handle errors, including rpc, when retrieving schema items in `SchemaFormatsProvider`
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/core/ecschema-metadata/package.json
+++ b/core/ecschema-metadata/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/ecschema-metadata",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "ECObjects core concepts in typescript",
   "license": "MIT",
   "main": "lib/cjs/ecschema-metadata.js",
@@ -73,4 +77,8 @@
   "nyc": {
     "extends": "./node_modules/@itwin/build-tools/.nycrc"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/core/ecschema-rpc/common/CHANGELOG.json
+++ b/core/ecschema-rpc/common/CHANGELOG.json
@@ -2,6 +2,45 @@
   "name": "@itwin/ecschema-rpcinterface-common",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/ecschema-rpcinterface-common_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/ecschema-rpcinterface-common_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/ecschema-rpcinterface-common_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/ecschema-rpcinterface-common_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/ecschema-rpcinterface-common_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {
+        "none": [
+          {
+            "comment": "Deprecated `getSchemaSync` method from ECSchemaRpcLocater."
+          }
+        ]
+      }
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/ecschema-rpcinterface-common_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/core/ecschema-rpc/common/CHANGELOG.md
+++ b/core/ecschema-rpc/common/CHANGELOG.md
@@ -1,6 +1,37 @@
 # Change Log - @itwin/ecschema-rpcinterface-common
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+### Updates
+
+- Deprecated `getSchemaSync` method from ECSchemaRpcLocater.
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/core/ecschema-rpc/common/package.json
+++ b/core/ecschema-rpc/common/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/ecschema-rpcinterface-common",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "Schema RPC Interface common interface",
   "main": "lib/cjs/ecschema-rpc-interface.js",
   "module": "lib/esm/ecschema-rpc-interface.js",
@@ -50,4 +54,8 @@
     "rimraf": "^6.0.1",
     "typescript": "~5.6.2"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/core/ecschema-rpc/impl/CHANGELOG.json
+++ b/core/ecschema-rpc/impl/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/ecschema-rpcinterface-impl",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/ecschema-rpcinterface-impl_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/ecschema-rpcinterface-impl_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/ecschema-rpcinterface-impl_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/ecschema-rpcinterface-impl_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/ecschema-rpcinterface-impl_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/ecschema-rpcinterface-impl_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/core/ecschema-rpc/impl/CHANGELOG.md
+++ b/core/ecschema-rpc/impl/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Change Log - @itwin/ecschema-rpcinterface-impl
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+_Version update only_
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/core/ecschema-rpc/impl/package.json
+++ b/core/ecschema-rpc/impl/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/ecschema-rpcinterface-impl",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "Schema RPC Interface backend implementation",
   "main": "lib/cjs/ecschema-rpc-impl.js",
   "module": "lib/esm/ecschema-rpc-impl.js",
@@ -54,4 +58,8 @@
     "rimraf": "^6.0.1",
     "typescript": "~5.6.2"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/core/ecsql/common/CHANGELOG.json
+++ b/core/ecsql/common/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/ecsql-common",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/ecsql-common_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/ecsql-common_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/ecsql-common_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/ecsql-common_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/ecsql-common_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/ecsql-common_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/core/ecsql/common/CHANGELOG.md
+++ b/core/ecsql/common/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Change Log - @itwin/ecsql-common
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+_Version update only_
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/core/ecsql/common/package.json
+++ b/core/ecsql/common/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/ecsql-common",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "ECSql component that can be reference on backend and frontend",
   "main": "lib/cjs/ecsql-common.js",
   "module": "lib/esm/ecsql-common.js",
@@ -55,4 +59,8 @@
     "extends": "./node_modules/@itwin/build-tools/.nycrc",
     "all": true
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/core/electron/CHANGELOG.json
+++ b/core/electron/CHANGELOG.json
@@ -2,6 +2,45 @@
   "name": "@itwin/core-electron",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/core-electron_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/core-electron_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/core-electron_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/core-electron_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/core-electron_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {
+        "none": [
+          {
+            "comment": "Add support for Electron 36"
+          }
+        ]
+      }
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/core-electron_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/core/electron/CHANGELOG.md
+++ b/core/electron/CHANGELOG.md
@@ -1,6 +1,37 @@
 # Change Log - @itwin/core-electron
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+### Updates
+
+- Add support for Electron 36
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/core/electron/package.json
+++ b/core/electron/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/core-electron",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "iTwin.js ElectronHost and ElectronApp",
   "license": "MIT",
   "engines": {
@@ -71,4 +75,8 @@
     "open": "^7.0.0",
     "username": "^7.0.0"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/core/express-server/CHANGELOG.json
+++ b/core/express-server/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/express-server",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/express-server_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/express-server_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/express-server_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/express-server_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/express-server_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/express-server_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/core/express-server/CHANGELOG.md
+++ b/core/express-server/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Change Log - @itwin/express-server
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+_Version update only_
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/core/express-server/package.json
+++ b/core/express-server/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/express-server",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "iTwin.js express utilities",
   "main": "lib/cjs/express-server.js",
   "module": "lib/esm/express-server.js",
@@ -70,4 +74,8 @@
   "nyc": {
     "extends": "./node_modules/@itwin/build-tools/.nycrc"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/core/extension/CHANGELOG.json
+++ b/core/extension/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/core-extension",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/core-extension_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/core-extension_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/core-extension_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/core-extension_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/core-extension_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/core-extension_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/core/extension/CHANGELOG.md
+++ b/core/extension/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Change Log - @itwin/core-extension
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+_Version update only_
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/core/extension/package.json
+++ b/core/extension/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/core-extension",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "iTwin.js Extension API",
   "type": "module",
   "typings": "index.d.ts",
@@ -44,4 +48,8 @@
     "rimraf": "^6.0.1",
     "typescript": "~5.6.2"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/core/frontend-devtools/CHANGELOG.json
+++ b/core/frontend-devtools/CHANGELOG.json
@@ -2,6 +2,45 @@
   "name": "@itwin/frontend-devtools",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/frontend-devtools_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/frontend-devtools_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/frontend-devtools_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/frontend-devtools_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/frontend-devtools_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {
+        "none": [
+          {
+            "comment": "fdt tooltips outputs contour line information."
+          }
+        ]
+      }
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/frontend-devtools_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/core/frontend-devtools/CHANGELOG.md
+++ b/core/frontend-devtools/CHANGELOG.md
@@ -1,6 +1,37 @@
 # Change Log - @itwin/frontend-devtools
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+### Updates
+
+- fdt tooltips outputs contour line information.
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/core/frontend-devtools/package.json
+++ b/core/frontend-devtools/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/frontend-devtools",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "Debug menu and supporting UI widgets",
   "main": "lib/cjs/frontend-devtools.js",
   "module": "lib/esm/frontend-devtools.js",
@@ -51,4 +55,8 @@
     "rimraf": "^6.0.1",
     "typescript": "~5.6.2"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/core/frontend/CHANGELOG.json
+++ b/core/frontend/CHANGELOG.json
@@ -2,6 +2,69 @@
   "name": "@itwin/core-frontend",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/core-frontend_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/core-frontend_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/core-frontend_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/core-frontend_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/core-frontend_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {
+        "none": [
+          {
+            "comment": "Made QuadIdProps public"
+          },
+          {
+            "comment": "Fix issue with WMTS server using ResourceURL"
+          },
+          {
+            "comment": "Added new `MapLayerSessionManager` API.  Minor additions to `MapCartoRectangle` and `QuadId` classes."
+          },
+          {
+            "comment": "Add `@itwin/ecschema-metadata`, `@itwin/ecschema-rpcinterface-common` peer dependencies. Make iModel-specific `SchemaContext` available on `IModelConnection` through the new `schemaContext` getter."
+          },
+          {
+            "comment": "Deprecate `quantityType` getters for subclasses of `FormattedQuantityDescription` and allow passing in `kindOfQuantityName` to constructor"
+          },
+          {
+            "comment": "Add `formatsProvider` property to `IModelApp` and `IModelAppOptions`, new `QuantityFormatter` helper methods to help consumers supply their own format specifications for formatting numeric values."
+          },
+          {
+            "comment": "Add Viewport.backgroundMapTileTreeReference"
+          },
+          {
+            "comment": "Added TileAdmin.Options.disablePolyfaceDecimation."
+          },
+          {
+            "comment": "HitDetail and Viewport.readPixels include contour line information."
+          }
+        ]
+      }
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/core-frontend_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/core/frontend/CHANGELOG.md
+++ b/core/frontend/CHANGELOG.md
@@ -1,6 +1,45 @@
 # Change Log - @itwin/core-frontend
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+### Updates
+
+- Made QuadIdProps public
+- Fix issue with WMTS server using ResourceURL
+- Added new `MapLayerSessionManager` API.  Minor additions to `MapCartoRectangle` and `QuadId` classes.
+- Add `@itwin/ecschema-metadata`, `@itwin/ecschema-rpcinterface-common` peer dependencies. Make iModel-specific `SchemaContext` available on `IModelConnection` through the new `schemaContext` getter.
+- Deprecate `quantityType` getters for subclasses of `FormattedQuantityDescription` and allow passing in `kindOfQuantityName` to constructor
+- Add `formatsProvider` property to `IModelApp` and `IModelAppOptions`, new `QuantityFormatter` helper methods to help consumers supply their own format specifications for formatting numeric values.
+- Add Viewport.backgroundMapTileTreeReference
+- Added TileAdmin.Options.disablePolyfaceDecimation.
+- HitDetail and Viewport.readPixels include contour line information.
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/core/frontend/package.json
+++ b/core/frontend/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/core-frontend",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "iTwin.js frontend components",
   "main": "lib/cjs/core-frontend.js",
   "module": "lib/esm/core-frontend.js",
@@ -99,4 +103,8 @@
     "fuse.js": "^3.3.0",
     "wms-capabilities": "0.4.0"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/core/geometry/CHANGELOG.json
+++ b/core/geometry/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/core-geometry",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/core-geometry_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/core-geometry_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/core-geometry_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/core-geometry_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/core-geometry_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/core-geometry_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/core/geometry/CHANGELOG.md
+++ b/core/geometry/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Change Log - @itwin/core-geometry
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+_Version update only_
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/core/geometry/package.json
+++ b/core/geometry/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/core-geometry",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "iTwin.js Core Geometry library",
   "main": "lib/cjs/core-geometry.js",
   "module": "lib/esm/core-geometry.js",
@@ -52,4 +56,8 @@
     "@itwin/core-bentley": "workspace:*",
     "flatbuffers": "~1.12.0"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/core/hypermodeling/CHANGELOG.json
+++ b/core/hypermodeling/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/hypermodeling-frontend",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/hypermodeling-frontend_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/hypermodeling-frontend_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/hypermodeling-frontend_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/hypermodeling-frontend_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/hypermodeling-frontend_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/hypermodeling-frontend_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/core/hypermodeling/CHANGELOG.md
+++ b/core/hypermodeling/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Change Log - @itwin/hypermodeling-frontend
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+_Version update only_
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/core/hypermodeling/package.json
+++ b/core/hypermodeling/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/hypermodeling-frontend",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "iTwin.js hypermodeling package",
   "main": "lib/cjs/hypermodeling-frontend.js",
   "module": "lib/esm/hypermodeling-frontend.js",
@@ -72,4 +76,8 @@
   "nyc": {
     "extends": "./node_modules/@itwin/build-tools/.nycrc"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/core/i18n/CHANGELOG.json
+++ b/core/i18n/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/core-i18n",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/core-i18n_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/core-i18n_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/core-i18n_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/core-i18n_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/core-i18n_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/core-i18n_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/core/i18n/CHANGELOG.md
+++ b/core/i18n/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Change Log - @itwin/core-i18n
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+_Version update only_
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/core/i18n/package.json
+++ b/core/i18n/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/core-i18n",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "iTwin.js localization code",
   "main": "lib/cjs/core-i18n.js",
   "module": "lib/esm/core-i18n.js",
@@ -74,4 +78,8 @@
     "i18next-browser-languagedetector": "^6.1.2",
     "i18next-http-backend": "^3.0.2"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/core/markup/CHANGELOG.json
+++ b/core/markup/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/core-markup",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/core-markup_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/core-markup_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/core-markup_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/core-markup_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/core-markup_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/core-markup_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/core/markup/CHANGELOG.md
+++ b/core/markup/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Change Log - @itwin/core-markup
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+_Version update only_
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/core/markup/package.json
+++ b/core/markup/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/core-markup",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "iTwin.js markup package",
   "main": "lib/cjs/core-markup.js",
   "module": "lib/esm/core-markup.js",
@@ -74,4 +78,8 @@
   "nyc": {
     "extends": "./node_modules/@itwin/build-tools/.nycrc"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/core/mobile/CHANGELOG.json
+++ b/core/mobile/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/core-mobile",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/core-mobile_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/core-mobile_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/core-mobile_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/core-mobile_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/core-mobile_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/core-mobile_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/core/mobile/CHANGELOG.md
+++ b/core/mobile/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Change Log - @itwin/core-mobile
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+_Version update only_
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/core/mobile/package.json
+++ b/core/mobile/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/core-mobile",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "iTwin.js MobileHost and MobileApp",
   "license": "MIT",
   "engines": {
@@ -66,4 +70,8 @@
     "rimraf": "^6.0.1",
     "typescript": "~5.6.2"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/core/orbitgt/CHANGELOG.json
+++ b/core/orbitgt/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/core-orbitgt",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/core-orbitgt_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/core-orbitgt_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/core-orbitgt_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/core-orbitgt_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/core-orbitgt_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/core-orbitgt_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/core/orbitgt/CHANGELOG.md
+++ b/core/orbitgt/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Change Log - @itwin/core-orbitgt
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+_Version update only_
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/core/orbitgt/package.json
+++ b/core/orbitgt/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/core-orbitgt",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "",
   "main": "lib/cjs/core-orbitgt.js",
   "module": "lib/esm/core-orbitgt.js",
@@ -50,4 +54,8 @@
   "nyc": {
     "extends": "./node_modules/@itwin/build-tools/.nycrc"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/core/quantity/CHANGELOG.json
+++ b/core/quantity/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/core-quantity",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/core-quantity_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/core-quantity_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/core-quantity_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/core-quantity_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/core-quantity_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/core-quantity_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/core/quantity/CHANGELOG.md
+++ b/core/quantity/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Change Log - @itwin/core-quantity
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+_Version update only_
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/core/quantity/package.json
+++ b/core/quantity/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/core-quantity",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "Quantity parsing, formatting and conversions for iModel.js",
   "main": "lib/cjs/core-quantity.js",
   "module": "lib/esm/core-quantity.js",
@@ -47,4 +51,8 @@
   "peerDependencies": {
     "@itwin/core-bentley": "workspace:*"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/core/webgl-compatibility/CHANGELOG.json
+++ b/core/webgl-compatibility/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/webgl-compatibility",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/webgl-compatibility_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/webgl-compatibility_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/webgl-compatibility_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/webgl-compatibility_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/webgl-compatibility_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/webgl-compatibility_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/core/webgl-compatibility/CHANGELOG.md
+++ b/core/webgl-compatibility/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Change Log - @itwin/webgl-compatibility
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+_Version update only_
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/core/webgl-compatibility/package.json
+++ b/core/webgl-compatibility/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/webgl-compatibility",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "APIs for determining the level of compatibility of a browser+device with the iTwin.js rendering system.",
   "license": "MIT",
   "main": "lib/cjs/webgl-compatibility.js",
@@ -56,4 +60,8 @@
     "typescript": "~5.6.2",
     "webpack": "^5.97.1"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/docs/changehistory/5.1.0.md
+++ b/docs/changehistory/5.1.0.md
@@ -1,9 +1,9 @@
 ---
-publish: false
+deltaDoc: true
+version: '5.1.0'
 ---
-<<<<<<< HEAD
 
-# NextVersion
+# 5.1.0 Change Notes
 
 Table of contents:
 
@@ -25,7 +25,4 @@ In addition to [already supported Electron versions](../learning/SupportedPlatfo
 ### @itwin/presentation-frontend
 
 - The `PresentationManagerProps.schemaContextProvider` property has been deprecated. Starting with `5.0` release, `SchemaContext` is always available on [IModelConnection]($core-frontend), so this prop is no longer needed. If supplied, it will still be preferred over the iModel's schema context, until the property is removed completely in a future release.
-=======
-# NextVersion
 
->>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/docs/changehistory/index.md
+++ b/docs/changehistory/index.md
@@ -1,4 +1,5 @@
 
+<<<<<<< HEAD
 # 4.10.0 Change Notes
 
 Table of contents:
@@ -179,3 +180,27 @@ In addition to [already supported Electron versions](../learning/SupportedPlatfo
 ### @itwin/presentation-common
 
 - All public methods of [PresentationRpcInterface]($presentation-common) have been deprecated. Going forward, RPC interfaces should not be called directly. Public wrappers such as [PresentationManager]($presentation-frontend) should be used instead.
+=======
+# 5.1.0 Change Notes
+
+Table of contents:
+
+- [Electron 36 support](#electron-36-support)
+- [API deprecations](#api-deprecations)
+  - [@itwin/presentation-backend](#itwinpresentation-backend)
+  - [@itwin/presentation-frontend](#itwinpresentation-frontend)
+
+## Electron 36 support
+
+In addition to [already supported Electron versions](../learning/SupportedPlatforms.md#electron), iTwin.js now supports [Electron 36](https://www.electronjs.org/blog/electron-36-0).
+
+## API deprecations
+
+### @itwin/presentation-backend
+
+- The `PresentationManagerProps.schemaContextProvider` property has been deprecated. Starting with `5.0` release, `SchemaContext` is always available on [IModelDb]($core-backend), so this prop is no longer needed. If supplied, it will still be preferred over the iModel's schema context, until the property is removed completely in a future release.
+
+### @itwin/presentation-frontend
+
+- The `PresentationManagerProps.schemaContextProvider` property has been deprecated. Starting with `5.0` release, `SchemaContext` is always available on [IModelConnection]($core-frontend), so this prop is no longer needed. If supplied, it will still be preferred over the iModel's schema context, until the property is removed completely in a future release.
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/docs/changehistory/leftNav.md
+++ b/docs/changehistory/leftNav.md
@@ -10,6 +10,10 @@ closedPanels: ["Previous Versions", "Changelogs"]
 
 ### Versions
 
+<<<<<<< HEAD
+=======
+- [5.1.0](./5.1.0.md)
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 - [4.10.0](./4.10.0.md)
 - [4.9.0](./4.9.0.md)
 - [4.8.0](./4.8.0.md)
@@ -75,3 +79,7 @@ closedPanels: ["Previous Versions", "Changelogs"]
 - [core-common](../reference/core-common/changelog)
 - [core-geometry](../reference/core-geometry/changelog)
 - [core-bentley](../reference/core-bentley/changelog)
+<<<<<<< HEAD
+=======
+
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/docs/config/docSites.json
+++ b/docs/config/docSites.json
@@ -40,7 +40,11 @@
       "Samples": "sample-showcase",
       "Learning": "learning",
       "API": "reference",
+<<<<<<< HEAD
       "v4.0.0": "changehistory"
+=======
+      "v5.5.0": "changehistory"
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
     },
     "archivedVersions": [
       {

--- a/domains/analytical/backend/CHANGELOG.json
+++ b/domains/analytical/backend/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/analytical-backend",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/analytical-backend_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/analytical-backend_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/analytical-backend_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/analytical-backend_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/analytical-backend_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/analytical-backend_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/domains/analytical/backend/CHANGELOG.md
+++ b/domains/analytical/backend/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Change Log - @itwin/analytical-backend
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+_Version update only_
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/domains/analytical/backend/package.json
+++ b/domains/analytical/backend/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/analytical-backend",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "main": "lib/cjs/analytical-backend.js",
   "module": "lib/esm/analytical-backend.js",
   "typings": "lib/cjs/analytical-backend",
@@ -74,4 +78,8 @@
   "nyc": {
     "extends": "./node_modules/@itwin/build-tools/.nycrc"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/domains/linear-referencing/backend/CHANGELOG.json
+++ b/domains/linear-referencing/backend/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/linear-referencing-backend",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/linear-referencing-backend_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/linear-referencing-backend_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/linear-referencing-backend_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/linear-referencing-backend_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/linear-referencing-backend_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/linear-referencing-backend_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/domains/linear-referencing/backend/CHANGELOG.md
+++ b/domains/linear-referencing/backend/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Change Log - @itwin/linear-referencing-backend
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+_Version update only_
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/domains/linear-referencing/backend/package.json
+++ b/domains/linear-referencing/backend/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/linear-referencing-backend",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "main": "lib/cjs/linear-referencing-backend.js",
   "module": "lib/esm/linear-referencing-backend.js",
   "typings": "lib/cjs/linear-referencing-backend",
@@ -74,4 +78,8 @@
   "nyc": {
     "extends": "./node_modules/@itwin/build-tools/.nycrc"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/domains/linear-referencing/common/CHANGELOG.json
+++ b/domains/linear-referencing/common/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/linear-referencing-common",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/linear-referencing-common_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/linear-referencing-common_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/linear-referencing-common_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/linear-referencing-common_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/linear-referencing-common_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/linear-referencing-common_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/domains/linear-referencing/common/CHANGELOG.md
+++ b/domains/linear-referencing/common/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Change Log - @itwin/linear-referencing-common
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+_Version update only_
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/domains/linear-referencing/common/package.json
+++ b/domains/linear-referencing/common/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/linear-referencing-common",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "main": "lib/cjs/linear-referencing-common.js",
   "module": "lib/esm/linear-referencing-common.js",
   "typings": "lib/cjs/linear-referencing-common",
@@ -56,4 +60,8 @@
     "rimraf": "^6.0.1",
     "typescript": "~5.6.2"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/domains/physical-material/backend/CHANGELOG.json
+++ b/domains/physical-material/backend/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/physical-material-backend",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/physical-material-backend_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/physical-material-backend_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/physical-material-backend_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/physical-material-backend_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/physical-material-backend_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/physical-material-backend_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/domains/physical-material/backend/CHANGELOG.md
+++ b/domains/physical-material/backend/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Change Log - @itwin/physical-material-backend
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+_Version update only_
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/domains/physical-material/backend/package.json
+++ b/domains/physical-material/backend/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/physical-material-backend",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "main": "lib/cjs/physical-material-backend.js",
   "module": "lib/esm/physical-material-backend.js",
   "typings": "lib/cjs/physical-material-backend",
@@ -70,4 +74,8 @@
   "nyc": {
     "extends": "./node_modules/@itwin/build-tools/.nycrc"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/editor/backend/CHANGELOG.json
+++ b/editor/backend/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/editor-backend",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/editor-backend_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/editor-backend_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/editor-backend_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/editor-backend_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/editor-backend_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/editor-backend_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/editor/backend/CHANGELOG.md
+++ b/editor/backend/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Change Log - @itwin/editor-backend
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+_Version update only_
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/editor/backend/package.json
+++ b/editor/backend/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/editor-backend",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "iTwin.js editor backend",
   "main": "lib/cjs/editor-backend.js",
   "module": "lib/esm/editor-backend.js",
@@ -61,4 +65,8 @@
   "dependencies": {
     "@itwin/editor-common": "workspace:*"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/editor/common/CHANGELOG.json
+++ b/editor/common/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/editor-common",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/editor-common_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/editor-common_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/editor-common_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/editor-common_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/editor-common_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/editor-common_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/editor/common/CHANGELOG.md
+++ b/editor/common/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Change Log - @itwin/editor-common
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+_Version update only_
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/editor/common/package.json
+++ b/editor/common/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/editor-common",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "iTwin.js editing properties common to frontend and backend",
   "main": "lib/cjs/editor-common.js",
   "module": "lib/esm/editor-common.js",
@@ -53,4 +57,8 @@
     "rimraf": "^6.0.1",
     "typescript": "~5.6.2"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/editor/frontend/CHANGELOG.json
+++ b/editor/frontend/CHANGELOG.json
@@ -2,6 +2,45 @@
   "name": "@itwin/editor-frontend",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/editor-frontend_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/editor-frontend_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/editor-frontend_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/editor-frontend_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/editor-frontend_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {
+        "none": [
+          {
+            "comment": "Draw dynamics as overlays if they belong to an overlay plan projection model."
+          }
+        ]
+      }
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/editor-frontend_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/editor/frontend/CHANGELOG.md
+++ b/editor/frontend/CHANGELOG.md
@@ -1,6 +1,37 @@
 # Change Log - @itwin/editor-frontend
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+### Updates
+
+- Draw dynamics as overlays if they belong to an overlay plan projection model.
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/editor/frontend/package.json
+++ b/editor/frontend/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/editor-frontend",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "iTwin.js frontend components",
   "main": "lib/cjs/editor-frontend.js",
   "module": "lib/esm/editor-frontend.js",
@@ -68,4 +72,8 @@
   "dependencies": {
     "@itwin/editor-common": "workspace:*"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/extensions/frontend-tiles/CHANGELOG.json
+++ b/extensions/frontend-tiles/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/frontend-tiles",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/frontend-tiles_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/frontend-tiles_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/frontend-tiles_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/frontend-tiles_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/frontend-tiles_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/frontend-tiles_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/extensions/frontend-tiles/CHANGELOG.md
+++ b/extensions/frontend-tiles/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Change Log - @itwin/frontend-tiles
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+_Version update only_
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/extensions/frontend-tiles/package.json
+++ b/extensions/frontend-tiles/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/frontend-tiles",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "Experimental alternative technique for visualizing the contents of iModels",
   "main": "lib/cjs/frontend-tiles.js",
   "module": "lib/esm/frontend-tiles.js",
@@ -74,4 +78,8 @@
     "typescript": "~5.6.2",
     "webpack": "^5.97.1"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/extensions/map-layers-auth/CHANGELOG.json
+++ b/extensions/map-layers-auth/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/map-layers-auth",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/map-layers-auth_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/map-layers-auth_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/map-layers-auth_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/map-layers-auth_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/map-layers-auth_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/map-layers-auth_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/extensions/map-layers-auth/CHANGELOG.md
+++ b/extensions/map-layers-auth/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Change Log - @itwin/map-layers-auth
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+_Version update only_
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/extensions/map-layers-auth/package.json
+++ b/extensions/map-layers-auth/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/map-layers-auth",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "Extension that adds a Map Layers Widget",
   "main": "lib/cjs/map-layers-auth.js",
   "module": "lib/esm/map-layers-auth.js",
@@ -90,4 +94,8 @@
       "mochaFile=lib/test/junit_results.xml"
     ]
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/extensions/map-layers-formats/CHANGELOG.json
+++ b/extensions/map-layers-formats/CHANGELOG.json
@@ -2,6 +2,51 @@
   "name": "@itwin/map-layers-formats",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/map-layers-formats_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/map-layers-formats_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/map-layers-formats_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/map-layers-formats_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/map-layers-formats_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {
+        "none": [
+          {
+            "comment": "Bug fix: Google Maps would only use the supplied session manager if an API key was also configured."
+          },
+          {
+            "comment": "Exposed some missing Google maps sessions structures."
+          },
+          {
+            "comment": "Revisted the Google Maps 2D tiles support to allow a custom session manager to be passed."
+          }
+        ]
+      }
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/map-layers-formats_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/extensions/map-layers-formats/CHANGELOG.md
+++ b/extensions/map-layers-formats/CHANGELOG.md
@@ -1,6 +1,39 @@
 # Change Log - @itwin/map-layers-formats
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+### Updates
+
+- Bug fix: Google Maps would only use the supplied session manager if an API key was also configured.
+- Exposed some missing Google maps sessions structures.
+- Revisted the Google Maps 2D tiles support to allow a custom session manager to be passed.
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/extensions/map-layers-formats/package.json
+++ b/extensions/map-layers-formats/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/map-layers-formats",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "Enables additional map-layers formats in iTwin.js",
   "main": "lib/cjs/map-layers-formats.js",
   "module": "lib/esm/map-layers-formats.js",
@@ -107,4 +111,8 @@
       "mochaFile=lib/test/junit_results.xml"
     ]
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/full-stack-tests/ecschema-rpc-interface/CHANGELOG.json
+++ b/full-stack-tests/ecschema-rpc-interface/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/ecschema-rpcinterface-tests",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/ecschema-rpcinterface-tests_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/ecschema-rpcinterface-tests_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/ecschema-rpcinterface-tests_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/ecschema-rpcinterface-tests_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/ecschema-rpcinterface-tests_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/ecschema-rpcinterface-tests_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/full-stack-tests/ecschema-rpc-interface/CHANGELOG.md
+++ b/full-stack-tests/ecschema-rpc-interface/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Change Log - @itwin/ecschema-rpcinterface-tests
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+_Version update only_
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/full-stack-tests/ecschema-rpc-interface/package.json
+++ b/full-stack-tests/ecschema-rpc-interface/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/ecschema-rpcinterface-tests",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "Integration tests for the Schema RPC Interface",
   "author": {
     "name": "Bentley Systems, Inc.",
@@ -76,4 +80,8 @@
     "webpack": "^5.97.1",
     "webpack-cli": "^5.0.1"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/full-stack-tests/rpc-interface/CHANGELOG.json
+++ b/full-stack-tests/rpc-interface/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/rpcinterface-full-stack-tests",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/rpcinterface-full-stack-tests_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/rpcinterface-full-stack-tests_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/rpcinterface-full-stack-tests_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/rpcinterface-full-stack-tests_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/rpcinterface-full-stack-tests_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/rpcinterface-full-stack-tests_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/full-stack-tests/rpc-interface/CHANGELOG.md
+++ b/full-stack-tests/rpc-interface/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Change Log - @itwin/rpcinterface-full-stack-tests
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+_Version update only_
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/full-stack-tests/rpc-interface/package.json
+++ b/full-stack-tests/rpc-interface/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/rpcinterface-full-stack-tests",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "Test the full iTwin.js Core stack (frontend and backend) using standard RPC interfaces",
   "license": "MIT",
   "scripts": {
@@ -83,4 +87,8 @@
     "webpack": "^5.97.1",
     "webpack-cli": "^5.0.1"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/presentation/backend/CHANGELOG.json
+++ b/presentation/backend/CHANGELOG.json
@@ -2,6 +2,51 @@
   "name": "@itwin/presentation-backend",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/presentation-backend_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/presentation-backend_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/presentation-backend_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/presentation-backend_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/presentation-backend_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {
+        "none": [
+          {
+            "comment": "Add Symbols to prevent duplicate instances of package"
+          },
+          {
+            "comment": "Fix `getDisplayLabelDefinitions` implementation not taking into account different formats and casings of full class name."
+          },
+          {
+            "comment": "Deprecate `PresentationManagerProps.schemaContextProvider`."
+          }
+        ]
+      }
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/presentation-backend_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/presentation/backend/CHANGELOG.md
+++ b/presentation/backend/CHANGELOG.md
@@ -1,6 +1,39 @@
 # Change Log - @itwin/presentation-backend
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+### Updates
+
+- Add Symbols to prevent duplicate instances of package
+- Fix `getDisplayLabelDefinitions` implementation not taking into account different formats and casings of full class name.
+- Deprecate `PresentationManagerProps.schemaContextProvider`.
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/presentation/backend/package.json
+++ b/presentation/backend/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/presentation-backend",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "Backend of iTwin.js Presentation library",
   "license": "MIT",
   "repository": {
@@ -108,4 +112,8 @@
     "rxjs-for-await": "^1.0.0",
     "semver": "^7.5.2"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/presentation/common/CHANGELOG.json
+++ b/presentation/common/CHANGELOG.json
@@ -2,6 +2,48 @@
   "name": "@itwin/presentation-common",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/presentation-common_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/presentation-common_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/presentation-common_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/presentation-common_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/presentation-common_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {
+        "none": [
+          {
+            "comment": "Export `Ruleset.schema.json` through exports field"
+          },
+          {
+            "comment": "Fix `InstanceKey.compare` implementation not taking into account different formats and casings of full class name."
+          }
+        ]
+      }
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/presentation-common_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/presentation/common/CHANGELOG.md
+++ b/presentation/common/CHANGELOG.md
@@ -1,6 +1,38 @@
 # Change Log - @itwin/presentation-common
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+### Updates
+
+- Export `Ruleset.schema.json` through exports field
+- Fix `InstanceKey.compare` implementation not taking into account different formats and casings of full class name.
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/presentation/common/package.json
+++ b/presentation/common/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/presentation-common",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "Common pieces for iModel.js presentation packages",
   "license": "MIT",
   "repository": {
@@ -111,4 +115,8 @@
     "typescript-json-schema": "^0.55.0",
     "yargs": "^17.4.0"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/presentation/common/src/presentation-common/PresentationManagerOptions.ts
+++ b/presentation/common/src/presentation-common/PresentationManagerOptions.ts
@@ -179,7 +179,11 @@ export interface DistinctValuesRequestOptions<TIModel, TDescriptor, TKeySet, TRu
 /**
  * Request type for element properties requests
  * @public
+<<<<<<< HEAD
  * @deprecated in 4.x. Should never be deprecated. Use [[SingleElementPropertiesRequestOptions]] or [[MultiElementPropertiesRequestOptions]] directly.
+=======
+ * @deprecated in 4.x - will not be removed until 2026-06-18. Should never be deprecated. Use [[SingleElementPropertiesRequestOptions]] or [[MultiElementPropertiesRequestOptions]] directly.
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
  */
 export type ElementPropertiesRequestOptions<TIModel, TParsedContent = ElementProperties> =
   | SingleElementPropertiesRequestOptions<TIModel>

--- a/presentation/frontend/CHANGELOG.json
+++ b/presentation/frontend/CHANGELOG.json
@@ -2,6 +2,48 @@
   "name": "@itwin/presentation-frontend",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/presentation-frontend_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/presentation-frontend_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/presentation-frontend_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/presentation-frontend_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/presentation-frontend_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {
+        "none": [
+          {
+            "comment": "Add Symbols to prevent duplicate instances of package"
+          },
+          {
+            "comment": "Deprecate `PresentationManagerProps.schemaContextProvider`."
+          }
+        ]
+      }
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/presentation-frontend_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/presentation/frontend/CHANGELOG.md
+++ b/presentation/frontend/CHANGELOG.md
@@ -1,6 +1,38 @@
 # Change Log - @itwin/presentation-frontend
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+### Updates
+
+- Add Symbols to prevent duplicate instances of package
+- Deprecate `PresentationManagerProps.schemaContextProvider`.
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/presentation/frontend/package.json
+++ b/presentation/frontend/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/presentation-frontend",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "Frontend of iModel.js Presentation library",
   "license": "MIT",
   "repository": {
@@ -97,4 +101,8 @@
     "typemoq": "^2.1.0",
     "typescript": "~5.6.2"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/tools/build/CHANGELOG.json
+++ b/tools/build/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/build-tools",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/build-tools_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/build-tools_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/build-tools_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/build-tools_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/build-tools_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/build-tools_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/tools/build/CHANGELOG.md
+++ b/tools/build/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Change Log - @itwin/build-tools
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+_Version update only_
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/tools/build/package.json
+++ b/tools/build/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/build-tools",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "Bentley build tools",
   "license": "MIT",
   "repository": {
@@ -51,4 +55,8 @@
     "@types/node": "~20.17.0",
     "eslint": "^9.13.0"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/tools/certa/CHANGELOG.json
+++ b/tools/certa/CHANGELOG.json
@@ -2,6 +2,45 @@
   "name": "@itwin/certa",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/certa_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/certa_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/certa_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/certa_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/certa_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {
+        "none": [
+          {
+            "comment": "Add support for Electron 36"
+          }
+        ]
+      }
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/certa_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/tools/certa/CHANGELOG.md
+++ b/tools/certa/CHANGELOG.md
@@ -1,6 +1,37 @@
 # Change Log - @itwin/certa
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+### Updates
+
+- Add support for Electron 36
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/tools/certa/package.json
+++ b/tools/certa/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/certa",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "A mocha-based integration test runner",
   "license": "MIT",
   "main": "bin/certa.js",
@@ -67,4 +71,8 @@
       "optional": true
     }
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/tools/ecschema2ts/CHANGELOG.json
+++ b/tools/ecschema2ts/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/ecschema2ts",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/ecschema2ts_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/ecschema2ts_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/ecschema2ts_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/ecschema2ts_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/ecschema2ts_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/ecschema2ts_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/tools/ecschema2ts/CHANGELOG.md
+++ b/tools/ecschema2ts/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Change Log - @itwin/ecschema2ts
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+_Version update only_
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/tools/ecschema2ts/package.json
+++ b/tools/ecschema2ts/package.json
@@ -2,7 +2,11 @@
   "name": "@itwin/ecschema2ts",
   "description": "Command line tools that takes an ECSchema xml file and outputs a typescript module",
   "license": "MIT",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "bin": {
     "ecschema2ts": "./bin/index.js"
   },
@@ -70,4 +74,8 @@
   "nyc": {
     "extends": "./node_modules/@itwin/build-tools/.nycrc"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/tools/perf-tools/CHANGELOG.json
+++ b/tools/perf-tools/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/perf-tools",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/perf-tools_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/perf-tools_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/perf-tools_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/perf-tools_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/perf-tools_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/perf-tools_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/tools/perf-tools/CHANGELOG.md
+++ b/tools/perf-tools/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Change Log - @itwin/perf-tools
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+_Version update only_
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/tools/perf-tools/package.json
+++ b/tools/perf-tools/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/perf-tools",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "Tools for collecting and reporting performance data",
   "main": "lib/cjs/perf-tools.js",
   "typings": "lib/cjs/perf-tools",
@@ -42,4 +46,8 @@
     "rimraf": "^6.0.1",
     "typescript": "~5.6.2"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/ui/appui-abstract/CHANGELOG.json
+++ b/ui/appui-abstract/CHANGELOG.json
@@ -2,6 +2,45 @@
   "name": "@itwin/appui-abstract",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/appui-abstract_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/appui-abstract_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/appui-abstract_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/appui-abstract_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/appui-abstract_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {
+        "none": [
+          {
+            "comment": "Deprecate `quantityType` in `PropertyDescription`, replaced by optional `kindOfQuantityName`"
+          }
+        ]
+      }
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/appui-abstract_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/ui/appui-abstract/CHANGELOG.md
+++ b/ui/appui-abstract/CHANGELOG.md
@@ -1,6 +1,37 @@
 # Change Log - @itwin/appui-abstract
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+### Updates
+
+- Deprecate `quantityType` in `PropertyDescription`, replaced by optional `kindOfQuantityName`
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/ui/appui-abstract/package.json
+++ b/ui/appui-abstract/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/appui-abstract",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "description": "iTwin.js UI abstractions",
   "main": "lib/cjs/appui-abstract.js",
   "module": "lib/esm/appui-abstract.js",
@@ -72,4 +76,8 @@
     "NOTE: these dependencies should be only for things that DO NOT APPEAR IN THE API",
     "NOTE: core-frontend should remain UI technology agnostic, so no react/angular dependencies are allowed"
   ]
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)

--- a/utils/workspace-editor/CHANGELOG.json
+++ b/utils/workspace-editor/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/workspace-editor",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.5.0",
+      "tag": "@itwin/workspace-editor_v5.5.0",
+      "date": "Wed, 18 Jun 2025 10:23:15 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.4.0",
+      "tag": "@itwin/workspace-editor_v5.4.0",
+      "date": "Wed, 18 Jun 2025 08:44:08 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.3.0",
+      "tag": "@itwin/workspace-editor_v5.3.0",
+      "date": "Wed, 18 Jun 2025 08:35:44 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/workspace-editor_v5.2.0",
+      "date": "Wed, 18 Jun 2025 08:22:51 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.1.0",
+      "tag": "@itwin/workspace-editor_v5.1.0",
+      "date": "Wed, 18 Jun 2025 07:51:18 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
       "version": "4.11.5",
       "tag": "@itwin/workspace-editor_v4.11.5",
       "date": "Fri, 06 Jun 2025 13:41:18 GMT",

--- a/utils/workspace-editor/CHANGELOG.md
+++ b/utils/workspace-editor/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Change Log - @itwin/workspace-editor
 
+<<<<<<< HEAD
 This log was last generated on Fri, 06 Jun 2025 13:44:02 GMT and should not be manually modified.
+=======
+This log was last generated on Wed, 18 Jun 2025 10:23:15 GMT and should not be manually modified.
+
+## 5.5.0
+Wed, 18 Jun 2025 10:23:15 GMT
+
+_Version update only_
+
+## 5.4.0
+Wed, 18 Jun 2025 08:44:08 GMT
+
+_Version update only_
+
+## 5.3.0
+Wed, 18 Jun 2025 08:35:44 GMT
+
+_Version update only_
+
+## 5.2.0
+Wed, 18 Jun 2025 08:22:51 GMT
+
+_Version update only_
+
+## 5.1.0
+Wed, 18 Jun 2025 07:51:18 GMT
+
+_Version update only_
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
 
 ## 4.11.5
 Fri, 06 Jun 2025 13:41:18 GMT

--- a/utils/workspace-editor/package.json
+++ b/utils/workspace-editor/package.json
@@ -2,7 +2,11 @@
   "name": "@itwin/workspace-editor",
   "license": "MIT",
   "main": "lib/WorkspaceEditor.js",
+<<<<<<< HEAD
   "version": "5.1.0-dev.36",
+=======
+  "version": "5.5.0",
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)
   "bin": {
     "WorkspaceEditor": "./lib/WorkspaceEditor.js"
   },
@@ -42,4 +46,8 @@
     "rimraf": "^6.0.1",
     "typescript": "~5.6.2"
   }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7b7e6332d (add deprecation dates using custom ESLint rule)


### PR DESCRIPTION
This PR contains all changes after running lint-deprecation ESLint rule and merging with master. Manual intervention required: solve conflicts in this branch and merge PR into master. This happened because @deprecation comments in master and in release branch could not be merged automatically.