### PR TITLE
Merge @deprecation comment changes into master

### DIFF
--- a/common/config/azure-pipelines/jobs/version-bump.yaml
+++ b/common/config/azure-pipelines/jobs/version-bump.yaml
@@ -205,7 +205,11 @@ jobs:
           - bash: |
               commitHash=$(deprecationCommit.hash)
               echo "Attempting to cherry-pick commit: $commitHash"
+<<<<<<< HEAD
               if git cherry-pick $commitHash; then
+=======
+              if git cherry-pick -ff $commitHash; then
+>>>>>>> 110b264c5 (add deprecation dates using custom ESLint rule)
                 echo "Successfully applied deprecation comment updates to master"
                 git push https://$(MYGITHUBTOKEN)@github.com/augustasgri/itwinjs-core-fork HEAD:master
               else

--- a/presentation/common/src/presentation-common/PresentationManagerOptions.ts
+++ b/presentation/common/src/presentation-common/PresentationManagerOptions.ts
@@ -179,7 +179,11 @@ export interface DistinctValuesRequestOptions<TIModel, TDescriptor, TKeySet, TRu
 /**
  * Request type for element properties requests
  * @public
+<<<<<<< HEAD
  * @deprecated in 4.x. Should never be deprecated. Use [[SingleElementPropertiesRequestOptions]] or [[MultiElementPropertiesRequestOptions]] directly.
+=======
+ * @deprecated in 4.x - will not be removed until 2026-06-18. Should never be deprecated. Use [[SingleElementPropertiesRequestOptions]] or [[MultiElementPropertiesRequestOptions]] directly.
+>>>>>>> 110b264c5 (add deprecation dates using custom ESLint rule)
  */
 export type ElementPropertiesRequestOptions<TIModel, TParsedContent = ElementProperties> =
   | SingleElementPropertiesRequestOptions<TIModel>


### PR DESCRIPTION
This PR contains all changes after running lint-deprecation ESLint rule and merging with master. Manual intervention required: solve conflicts in this branch and merge PR into master. This happened because @deprecation comments in master and in release branch could not be merged automatically.