### PR TITLE
Merge deprecation comment changes into master

### DIFF
--- a/common/config/eslint/eslint.config.deprecation-policy.js
+++ b/common/config/eslint/eslint.config.deprecation-policy.js
@@ -23,7 +23,7 @@ module.exports = [
         "warn",
         {
           removeOldDates: true,
-          addVersion: "5.17.0"
+          addVersion: "5.17.1"
         }
       ]
     }

--- a/core/backend/src/BackendHubAccess.ts
+++ b/core/backend/src/BackendHubAccess.ts
@@ -31,7 +31,11 @@ export class LockConflict extends IModelError {
 }
 
 /** The state of a lock. See [Acquiring locks on elements.]($docs/learning/backend/ConcurrencyControl.md#acquiring-locks-on-elements).
+<<<<<<< HEAD
  * @deprecated in 5.16.6. Should be removed until 2026-06-30. Conflict. Use [LockState]($common)
+=======
+ * @deprecated in 5.17.1 - will not be removed until 2026-06-30. Will conflict until 2026-06-30. Foo bar. Use [LockState]($common)
+>>>>>>> fe60da7eb (Apply deprecation date rule for v5.17.1)
  * @public
  */
 export enum LockState {


### PR DESCRIPTION
This PR contains all changes after running lint-deprecation ESLint rule and merging with master. Manual intervention required: solve conflicts in this branch and merge PR into master. This happened because deprecation comments in master and in release branch could not be merged automatically.