### PR TITLE
Merge deprecation comment changes into master

### DIFF
--- a/common/config/eslint/eslint.config.deprecation-policy.js
+++ b/common/config/eslint/eslint.config.deprecation-policy.js
@@ -23,7 +23,7 @@ module.exports = [
         "warn",
         {
           removeOldDates: true,
-          addVersion: "5.17.8"
+          addVersion: "5.17.9"
         }
       ]
     }

--- a/core/backend/src/BackendHubAccess.ts
+++ b/core/backend/src/BackendHubAccess.ts
@@ -31,7 +31,11 @@ export class LockConflict extends IModelError {
 }
 
 /** The state of a lock. See [Acquiring locks on elements.]($docs/learning/backend/ConcurrencyControl.md#acquiring-locks-on-elements).
+<<<<<<< HEAD
  * @deprecated in 5.17.8 - will not be removed until 2026-07-07. Use [LockState]($common)
+=======
+ * @deprecated in 5.17.9 - will not be removed until 2026-07-08. Use [LockState]($common)
+>>>>>>> fc9056195 (Apply deprecation date rule for v5.17.9)
  * @public
  */
 export enum LockState {


### PR DESCRIPTION
This PR contains all changes after running lint-deprecation ESLint rule and merging with master. Manual intervention required: solve conflicts in this branch and merge PR into master. This happened because deprecation comments in master and in release branch could not be merged automatically. @augustasgri